### PR TITLE
Cpr on unsatisfied

### DIFF
--- a/integrationtest/src/test/java/dk/kvalitetsit/hjemmebehandling/integrationtest/CarePlanIntegrationTest.java
+++ b/integrationtest/src/test/java/dk/kvalitetsit/hjemmebehandling/integrationtest/CarePlanIntegrationTest.java
@@ -123,7 +123,7 @@ public class CarePlanIntegrationTest extends AbstractIntegrationTest {
         boolean onlyActiveCarePlans = false;
 
         // Act
-        ApiResponse<List<CarePlanDto>> response = subject.searchCarePlansWithHttpInfo(cpr, null, onlyActiveCarePlans, null, null);
+        ApiResponse<List<CarePlanDto>> response = subject.searchCarePlansWithHttpInfo(cpr, null, onlyActiveCarePlans, 1, 10);
 
         // Assert
         assertEquals(200, response.getStatusCode());

--- a/service/src/main/java/dk/kvalitetsit/hjemmebehandling/fhir/FhirClient.java
+++ b/service/src/main/java/dk/kvalitetsit/hjemmebehandling/fhir/FhirClient.java
@@ -51,38 +51,25 @@ public class FhirClient {
 
         return lookupCarePlansByCriteria(criteria);
     }
-
-    public FhirLookupResult lookupCarePlans(boolean onlyActiveCarePlans, int offset, int count) {
+    
+    
+    public FhirLookupResult lookupCarePlans(Optional<String> cpr,Instant unsatisfiedToDate, boolean onlyActiveCarePlans,boolean onlyUnSatisfied, int offset, int count) {
         var criteria = new ArrayList<ICriterion<?>>();
 
-        // The criterion expresses that the careplan must no longer be satisfied at the given point in time.
         var organizationCriterion = buildOrganizationCriterion();
         criteria.addAll(List.of(organizationCriterion));
-        if(onlyActiveCarePlans) {
-            var statusCriterion = CarePlan.STATUS.exactly().code(CarePlan.CarePlanStatus.ACTIVE.toCode());
-            criteria.add(statusCriterion);
-        } else {
-        	var statusCriterion = CarePlan.STATUS.exactly().code(CarePlan.CarePlanStatus.COMPLETED.toCode());
-        	criteria.add(statusCriterion);
-        }
-
-        var sortSpec = new SortSpec(SearchParameters.CAREPLAN_SATISFIED_UNTIL, SortOrderEnum.ASC);
-
-        return lookupCarePlansByCriteria(criteria, Optional.of(sortSpec), Optional.of(offset), Optional.of(count));
-    }
-    
-    
-    public FhirLookupResult lookupCarePlansUnsatisfiedAt(Optional<String> cpr,Instant pointInTime, boolean onlyActiveCarePlans, int offset, int count) {
-        var criteria = new ArrayList<ICriterion<?>>();
 
         // The criterion expresses that the careplan must no longer be satisfied at the given point in time.
-        var satisfiedUntilCriterion = new DateClientParam(SearchParameters.CAREPLAN_SATISFIED_UNTIL).before().millis(Date.from(pointInTime));
-        var organizationCriterion = buildOrganizationCriterion();
-        criteria.addAll(List.of(satisfiedUntilCriterion, organizationCriterion));
+        if(onlyUnSatisfied){
+            var satisfiedUntilCriterion = new DateClientParam(SearchParameters.CAREPLAN_SATISFIED_UNTIL).before().millis(Date.from(unsatisfiedToDate));
+            criteria.add(satisfiedUntilCriterion);
+        }
+
         if(onlyActiveCarePlans) {
             var statusCriterion = CarePlan.STATUS.exactly().code(CarePlan.CarePlanStatus.ACTIVE.toCode());
             criteria.add(statusCriterion);
         }
+
         if(cpr.isPresent()){
             var cprCriterion = Patient.IDENTIFIER.exactly().systemAndValues(Systems.CPR, cpr.get());
             criteria.add(cprCriterion);

--- a/service/src/main/java/dk/kvalitetsit/hjemmebehandling/service/CarePlanService.java
+++ b/service/src/main/java/dk/kvalitetsit/hjemmebehandling/service/CarePlanService.java
@@ -148,50 +148,12 @@ public class CarePlanService extends AccessValidatingService {
         fhirClient.updateCarePlan(completedCarePlan);
         return fhirMapper.mapCarePlan(completedCarePlan, lookupResult); // for auditlog
     }
-    
-    public List<CarePlanModel> getCarePlans(boolean onlyActiveCarePlans, PageDetails pageDetails) throws ServiceException {
-        int offset = pageDetails.getOffset();
-        int count = pageDetails.getPageSize();
-        
-        FhirLookupResult lookupResult = fhirClient.lookupCarePlans(onlyActiveCarePlans, offset,count);
-        if(lookupResult.getCarePlans().isEmpty()) {
-            return List.of();
-        }
 
-        // Map the resourecs
-        return lookupResult.getCarePlans()
-                .stream()
-                .map(cp -> fhirMapper.mapCarePlan(cp, lookupResult))
-                .collect(Collectors.toList());
-    }
-
-    
-    public List<CarePlanModel> getCarePlansByCpr(String cpr, boolean onlyActiveCarePlans) throws ServiceException {
-        // Look up the patient so that we may look up careplans by patientId.
-        Optional<Patient> patient = fhirClient.lookupPatientByCpr(cpr);
-        if(!patient.isPresent()) {
-            throw new IllegalStateException(String.format("Could not look up patient by cpr %s!", cpr));
-        }
-
-        // Look up the careplans along with related resources needed for mapping.
-        String patientId = patient.get().getIdElement().toUnqualifiedVersionless().toString();
-        FhirLookupResult lookupResult = fhirClient.lookupCarePlansByPatientId(patientId, onlyActiveCarePlans);
-        if(lookupResult.getCarePlans().isEmpty()) {
-            return List.of();
-        }
-
-        // Map the resourecs
-        return lookupResult.getCarePlans()
-                .stream()
-                .map(cp -> fhirMapper.mapCarePlan(cp, lookupResult))
-                .collect(Collectors.toList());
-    }
-
-    public List<CarePlanModel> getCarePlansWithUnsatisfiedSchedules(Optional<String> cpr, boolean onlyActiveCarePlans, PageDetails pageDetails) throws ServiceException {
+    public List<CarePlanModel> getCarePlansWithFilters(Optional<String> cpr, boolean onlyActiveCarePlans, boolean onlyUnSatisfied, PageDetails pageDetails) throws ServiceException {
         Instant pointInTime = dateProvider.now();
         int offset = pageDetails.getOffset();
         int count = pageDetails.getPageSize();
-        FhirLookupResult lookupResult = fhirClient.lookupCarePlansUnsatisfiedAt(cpr,pointInTime, onlyActiveCarePlans, offset, count);
+        FhirLookupResult lookupResult = fhirClient.lookupCarePlans(cpr,pointInTime, onlyActiveCarePlans, onlyUnSatisfied, offset, count);
         if(lookupResult.getCarePlans().isEmpty()) {
             return List.of();
         }

--- a/service/src/test/java/dk/kvalitetsit/hjemmebehandling/fhir/FhirClientTest.java
+++ b/service/src/test/java/dk/kvalitetsit/hjemmebehandling/fhir/FhirClientTest.java
@@ -151,6 +151,7 @@ public class FhirClientTest {
         // Arrange
         Instant pointInTime = Instant.parse("2021-11-07T10:11:12.124Z");
         boolean onlyActiveCarePlans = true;
+        boolean useUnsatisfied = true;
         int offset = 2;
         int count = 4;
 
@@ -161,7 +162,7 @@ public class FhirClientTest {
         setupOrganization(SOR_CODE_1, ORGANIZATION_ID_1);
 
         // Act
-        FhirLookupResult result = subject.lookupCarePlansUnsatisfiedAt(Optional.empty(),pointInTime, onlyActiveCarePlans, offset, count);
+        FhirLookupResult result = subject.lookupCarePlans(Optional.empty(),pointInTime, onlyActiveCarePlans, useUnsatisfied, offset, count);
 
         // Assert
         assertEquals(1, result.getCarePlans().size());
@@ -174,6 +175,7 @@ public class FhirClientTest {
         var cpr = "0101011234";
         Instant pointInTime = Instant.parse("2021-11-07T10:11:12.124Z");
         boolean onlyActiveCarePlans = true;
+        boolean useUnsatisfied = true;
         int offset = 2;
         int count = 4;
 
@@ -192,7 +194,7 @@ public class FhirClientTest {
         setupOrganization(SOR_CODE_1, ORGANIZATION_ID_1);
 
         // Act
-        FhirLookupResult result = subject.lookupCarePlansUnsatisfiedAt(Optional.of(cpr),pointInTime, onlyActiveCarePlans, offset, count);
+        FhirLookupResult result = subject.lookupCarePlans(Optional.of(cpr),pointInTime, onlyActiveCarePlans, useUnsatisfied, offset, count);
 
         // Assert
         assertEquals(1, result.getCarePlans().size());
@@ -205,6 +207,7 @@ public class FhirClientTest {
         // Arrange
         Instant pointInTime = Instant.parse("2021-11-07T10:11:12.124Z");
         boolean onlyActiveCarePlans = true;
+        boolean useUnsatisfied = true;
         int offset = 2;
         int count = 4;
 
@@ -214,7 +217,7 @@ public class FhirClientTest {
         setupOrganization(SOR_CODE_1, ORGANIZATION_ID_1);
 
         // Act
-        FhirLookupResult result = subject.lookupCarePlansUnsatisfiedAt(Optional.empty(),pointInTime, onlyActiveCarePlans, offset, count);
+        FhirLookupResult result = subject.lookupCarePlans(Optional.empty(),pointInTime, onlyActiveCarePlans, useUnsatisfied, offset, count);
 
         // Assert
         assertEquals(0, result.getCarePlans().size());


### PR DESCRIPTION
Der er lavet en refaktor af controller-metoden 'searchCarePlans', eftersom den havde 3 typer af adfærd afhængig af hvilke argumenter der kom med ind. Den kalder nu altid den samme metode, uafhængigt af argumenter, og bruger derefter argumenterne til at tilføje flere kriterier, såfremt argumentet beder om det

Dette PR skal merges ind, lige før vi kan deploye det, og herefter skal det på DIAS og testes i isolation, for at sikre at det hele virker :) 